### PR TITLE
Ignore the simulation auth entries if the transaction already contained an auth

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
 /// Error Handling in `soroban_client` crate
 /// This module defines all possible error types used in the `soroban_client` crate.
-
 use stellar_baselib::xdr::SorobanTransactionData;
 use thiserror::Error;
 
@@ -39,7 +38,7 @@ pub enum Error {
     RestorationRequired(i64, SorobanTransactionData),
     /// Error for RPC failures, includes code and message
     #[error("RPCError {code}: {message}")]
-    RPCError { 
+    RPCError {
         /// The error code returned from the RPC
         code: i32,
         /// The error message returned from the RPC

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -37,7 +37,6 @@ pub fn assemble_transaction(
     // Calculate fees
     let classic_fee_num = tx.fee;
 
-    // FIXME Check if some auth were already provided in the tx 
     let auth = if let Some((_, a)) = simulation.to_result() {
         Some(a.try_into().expect("Cannot convert Vec to VecM"))
     } else {
@@ -54,6 +53,7 @@ pub fn assemble_transaction(
     let soroban_tx_data = simulation
         .to_transaction_data()
         .expect("No transaction data");
+
     // Create a transaction builder with updated fees and Soroban data
     let source_acc = Rc::new(RefCell::new(
         Account::new(
@@ -76,7 +76,13 @@ pub fn assemble_transaction(
             tx_builder.add_operation(
                 stellar_baselib::operation::Operation::invoke_host_function(
                     invoke_host_function_op.host_function,
-                    auth,
+                    // Ignore the simulation auth entries if the transaction already contained
+                    // auth. 
+                    if invoke_host_function_op.auth.is_empty() {
+                        auth
+                    } else {
+                        Some(invoke_host_function_op.auth)
+                    },
                     None,
                 )
                 .map_err(|_| Error::TransactionError)?,
@@ -113,15 +119,84 @@ mod test {
         account::{Account, AccountBehavior},
         transaction_builder::{TransactionBuilder, TransactionBuilderBehavior},
         xdr::{
-            AccountId, CreateAccountOp, Hash, HostFunction, InvokeContractArgs,
-            InvokeHostFunctionOp, Operation, OperationBody, PublicKey, ScAddress, ScSymbol, ScVal,
-            SorobanAuthorizationEntry, StringM, Uint256, VecM,
+            AccountId, CreateAccountOp, Hash, HostFunction, InvokeContractArgs, InvokeHostFunctionOp, Operation, OperationBody, PublicKey, ScAddress, ScSymbol, ScVal, SorobanAuthorizationEntry, SorobanAuthorizedFunction, SorobanAuthorizedInvocation, SorobanCredentials, StringM, Uint256, VecM
         },
     };
 
     use crate::{error::Error, transaction::{
         assemble_transaction, is_soroban_transaction, SimulateTransactionResponse,
     }};
+
+    #[test]
+    fn tx_with_auth() {
+
+        let source_account = Rc::new(RefCell::new(
+            Account::new(
+                "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+                "0",
+            )
+            .unwrap(),
+        ));
+        let network = "Network for tests";
+
+        let contract_address = ScAddress::Contract(Hash([0; 32]));
+        let function_name = ScSymbol::from(StringM::from_str("test").unwrap());
+        let auth = SorobanAuthorizationEntry { credentials: SorobanCredentials::SourceAccount, root_invocation: SorobanAuthorizedInvocation { function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs{ contract_address, function_name, args: VecM::<_>::try_from(Vec::new()).unwrap() }), sub_invocations: VecM::<_>::try_from(Vec::new()).unwrap()} };
+
+        let contract_address = ScAddress::Contract(Hash([0; 32]));
+        let function_name = ScSymbol::from(StringM::from_str("test").unwrap());
+        let op = Operation {
+            source_account: None,
+            body: OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
+                host_function: HostFunction::InvokeContract(InvokeContractArgs {
+                    contract_address,
+                    function_name,
+                    args: VecM::<ScVal>::try_from(Vec::new()).unwrap(),
+                }),
+                auth: VecM::<SorobanAuthorizationEntry>::try_from(vec![auth]).unwrap(),
+            }),
+        };
+
+        let mut builder = TransactionBuilder::new(source_account, network, None);
+        builder.fee(1000u32).set_timeout(30).unwrap();
+        builder.add_operation(op);
+        let tx = builder.build();
+        let simulation: SimulateTransactionResponse = serde_json::from_value(json!(
+        {
+            "transactionData": "AAAAAAAAAAIAAAAGAAAAAcwD/nT9D7Dc2LxRdab+2vEUF8B+XoN7mQW21oxPT8ALAAAAFAAAAAEAAAAHy8vNUZ8vyZ2ybPHW0XbSrRtP7gEWsJ6zDzcfY9P8z88AAAABAAAABgAAAAHMA/50/Q+w3Ni8UXWm/trxFBfAfl6De5kFttaMT0/ACwAAABAAAAABAAAAAgAAAA8AAAAHQ291bnRlcgAAAAASAAAAAAAAAAAg4dbAxsGAGICfBG3iT2cKGYQ6hK4sJWzZ6or1C5v6GAAAAAEAHfKyAAAFiAAAAIgAAAAAAAAAAw==",
+            "minResourceFee": "90353",
+            "events": [
+            ],
+            "results": [
+              {
+                "auth": [],
+                "xdr": "AAAAAwAAAAw="
+              }
+            ],
+            "cost": {
+              "cpuInsns": "1635562",
+              "memBytes": "1295756"
+            },
+            "latestLedger": 2552139
+          
+        }
+        )).unwrap();
+
+        let mut r = assemble_transaction(tx, network, simulation).unwrap();
+        let txr = r.build();
+        if let Some(ops) = txr.operations {
+
+            let op = ops[0].clone();
+            if let OperationBody::InvokeHostFunction(InvokeHostFunctionOp { host_function:_, auth }) = op.body {
+                //
+                //
+                assert_eq!(auth.len(), 1);
+                assert!(matches!(auth[0].credentials, SorobanCredentials::SourceAccount));
+            } else {
+                panic!("Failed")
+            }
+        }
+    }
 
     #[test]
     fn simulation_failed() {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -15,7 +15,6 @@ pub use stellar_baselib::{
     },
 };
 
-
 /// Assemble a [transaction](Transaction) with a [simulation](SimulateTransactionResponse)
 pub fn assemble_transaction(
     tx: Transaction,
@@ -41,7 +40,7 @@ pub fn assemble_transaction(
     let auth = if let Some((_, a)) = simulation.to_result() {
         Some(a.try_into().expect("Cannot convert Vec to VecM"))
     } else {
-        None 
+        None
     };
 
     let min_resource_fee = simulation
@@ -78,7 +77,7 @@ pub fn assemble_transaction(
                 stellar_baselib::operation::Operation::invoke_host_function(
                     invoke_host_function_op.host_function,
                     // Ignore the simulation auth entries if the transaction already contained
-                    // auth. 
+                    // auth.
                     if invoke_host_function_op.auth.is_empty() {
                         auth
                     } else {
@@ -110,7 +109,6 @@ fn is_soroban_transaction(tx: &Transaction) -> bool {
     false
 }
 
-
 #[cfg(test)]
 mod test {
     use std::{cell::RefCell, rc::Rc, str::FromStr};
@@ -120,17 +118,20 @@ mod test {
         account::{Account, AccountBehavior},
         transaction_builder::{TransactionBuilder, TransactionBuilderBehavior},
         xdr::{
-            AccountId, CreateAccountOp, Hash, HostFunction, InvokeContractArgs, InvokeHostFunctionOp, Operation, OperationBody, PublicKey, ScAddress, ScSymbol, ScVal, SorobanAuthorizationEntry, SorobanAuthorizedFunction, SorobanAuthorizedInvocation, SorobanCredentials, StringM, Uint256, VecM
+            AccountId, CreateAccountOp, Hash, HostFunction, InvokeContractArgs,
+            InvokeHostFunctionOp, Operation, OperationBody, PublicKey, ScAddress, ScSymbol, ScVal,
+            SorobanAuthorizationEntry, SorobanAuthorizedFunction, SorobanAuthorizedInvocation,
+            SorobanCredentials, StringM, Uint256, VecM,
         },
     };
 
-    use crate::{error::Error, transaction::{
-        assemble_transaction, is_soroban_transaction, SimulateTransactionResponse,
-    }};
+    use crate::{
+        error::Error,
+        transaction::{assemble_transaction, is_soroban_transaction, SimulateTransactionResponse},
+    };
 
     #[test]
     fn tx_with_auth() {
-
         let source_account = Rc::new(RefCell::new(
             Account::new(
                 "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
@@ -142,7 +143,17 @@ mod test {
 
         let contract_address = ScAddress::Contract(Hash([0; 32]));
         let function_name = ScSymbol::from(StringM::from_str("test").unwrap());
-        let auth = SorobanAuthorizationEntry { credentials: SorobanCredentials::SourceAccount, root_invocation: SorobanAuthorizedInvocation { function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs{ contract_address, function_name, args: VecM::<_>::try_from(Vec::new()).unwrap() }), sub_invocations: VecM::<_>::try_from(Vec::new()).unwrap()} };
+        let auth = SorobanAuthorizationEntry {
+            credentials: SorobanCredentials::SourceAccount,
+            root_invocation: SorobanAuthorizedInvocation {
+                function: SorobanAuthorizedFunction::ContractFn(InvokeContractArgs {
+                    contract_address,
+                    function_name,
+                    args: VecM::<_>::try_from(Vec::new()).unwrap(),
+                }),
+                sub_invocations: VecM::<_>::try_from(Vec::new()).unwrap(),
+            },
+        };
 
         let contract_address = ScAddress::Contract(Hash([0; 32]));
         let function_name = ScSymbol::from(StringM::from_str("test").unwrap());
@@ -179,18 +190,23 @@ mod test {
               "memBytes": "1295756"
             },
             "latestLedger": 2552139
-          
         }
         )).unwrap();
 
         let mut r = assemble_transaction(tx, network, simulation).unwrap();
         let txr = r.build();
         if let Some(ops) = txr.operations {
-
             let op = ops[0].clone();
-            if let OperationBody::InvokeHostFunction(InvokeHostFunctionOp { host_function:_, auth }) = op.body {
+            if let OperationBody::InvokeHostFunction(InvokeHostFunctionOp {
+                host_function: _,
+                auth,
+            }) = op.body
+            {
                 assert_eq!(auth.len(), 1);
-                assert!(matches!(auth[0].credentials, SorobanCredentials::SourceAccount));
+                assert!(matches!(
+                    auth[0].credentials,
+                    SorobanCredentials::SourceAccount
+                ));
             } else {
                 panic!("Failed")
             }
@@ -199,7 +215,6 @@ mod test {
 
     #[test]
     fn simulation_failed() {
-
         let source_account = Rc::new(RefCell::new(
             Account::new(
                 "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
@@ -230,8 +245,9 @@ mod test {
             "error": "This is an error",
             "latestLedger": 2552139
           }
-        
-        )).unwrap();
+
+        ))
+        .unwrap();
 
         let r = assemble_transaction(tx, network, simulation);
         assert!(matches!(r, Err(Error::SimulationFailed)));
@@ -261,9 +277,7 @@ mod test {
         builder.add_operation(op);
         let tx = builder.build();
 
-        assert!(
-            !is_soroban_transaction(&tx),
-        );
+        assert!(!is_soroban_transaction(&tx),);
 
         let simulation: SimulateTransactionResponse = serde_json::from_value(json!(
          {
@@ -284,8 +298,7 @@ mod test {
               "memBytes": "1295756"
             },
             "latestLedger": 2552139
-          }
-        
+        }
         )).unwrap();
 
         let r = assemble_transaction(tx, network, simulation);
@@ -320,9 +333,7 @@ mod test {
         builder.add_operation(op);
         let tx = builder.build();
 
-        assert!(
-            is_soroban_transaction(&tx),
-        );
+        assert!(is_soroban_transaction(&tx),);
     }
 
     #[test]
@@ -354,9 +365,7 @@ mod test {
         builder.add_operation(op);
         let tx = builder.build();
 
-        assert!(
-            !is_soroban_transaction(&tx),
-        );
+        assert!(!is_soroban_transaction(&tx),);
     }
     #[test]
     fn is_soroban_transaction_no_ops() {
@@ -373,6 +382,6 @@ mod test {
         builder.fee(1000u32).set_timeout(30).unwrap();
         let tx = builder.build();
 
-        assert!(!is_soroban_transaction(&tx), );
+        assert!(!is_soroban_transaction(&tx),);
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -15,6 +15,7 @@ pub use stellar_baselib::{
     },
 };
 
+
 /// Assemble a [transaction](Transaction) with a [simulation](SimulateTransactionResponse)
 pub fn assemble_transaction(
     tx: Transaction,
@@ -188,8 +189,6 @@ mod test {
 
             let op = ops[0].clone();
             if let OperationBody::InvokeHostFunction(InvokeHostFunctionOp { host_function:_, auth }) = op.body {
-                //
-                //
                 assert_eq!(auth.len(), 1);
                 assert!(matches!(auth[0].credentials, SorobanCredentials::SourceAccount));
             } else {


### PR DESCRIPTION
As stated in js SDK:
> If auth entries are already present, we consider this "advanced
> usage" and disregard ALL auth entries from the simulation.
> The intuition is "if auth exists, this tx has probably been
> simulated before"